### PR TITLE
Throw Incorrect Password when no Password Provided for Locked File

### DIFF
--- a/Sources/Zip/Zip.swift
+++ b/Sources/Zip/Zip.swift
@@ -96,15 +96,17 @@ extension Zip {
     repeat {
       if let cPassword = password?.cString(using: String.Encoding.ascii) {
         ret = unzOpenCurrentFilePassword(zip, cPassword)
-      } else {
-        ret = unzOpenCurrentFile(zip)
-      }
-      if ret != UNZ_OK {
         if ret == UNZ_BADPASSWORD {
           throw ZipError.incorrectPassword
-        } else {
-          throw ZipError.unzipFail
         }
+      } else {
+        ret = unzOpenCurrentFile(zip)
+        if ret == UNZ_PARAMERROR {
+          throw ZipError.incorrectPassword
+        }
+      }
+      if ret != UNZ_OK {
+        throw ZipError.unzipFail
       }
       var fileInfo = unz_file_info64()
       memset(&fileInfo, 0, MemoryLayout<unz_file_info>.size)

--- a/Tests/ZipTests/ZipTests.swift
+++ b/Tests/ZipTests/ZipTests.swift
@@ -232,6 +232,35 @@ class ZipTests: XCTestCase {
     XCTAssertTrue(fileManager.fileExists(atPath: destinationUrl.path))
   }
   
+  func testZipWithPasswordUnzipWithNoPassword() throws {
+    let imageURL1 = url(forResource: "3crBXeO", withExtension: "gif")!
+    let imageURL2 = url(forResource: "kYkLkPf", withExtension: "gif")!
+    let zipFilePath = try autoRemovingSandbox().appendingPathComponent("archive.zip")
+    try Zip.zipFiles(
+      paths: [imageURL1, imageURL2],
+      zipFilePath: zipFilePath,
+      password: "password",
+      progress: nil
+    )
+    let directoryName = zipFilePath.lastPathComponent.replacingOccurrences(
+      of: ".\(zipFilePath.pathExtension)",
+      with: ""
+    )
+    let destinationUrl = try autoRemovingSandbox()
+      .appendingPathComponent(directoryName, isDirectory: true)
+    XCTAssertThrowsError(
+      try Zip.unzipFile(
+        zipFilePath,
+        destination: destinationUrl,
+        overwrite: true,
+        password: nil,
+        progress: nil
+      )
+    ) { error in
+      XCTAssertEqual(error as? ZipError, .incorrectPassword)
+    }
+  }
+  
   func testZipUnzipIncorrectPassword() throws {
     let imageURL1 = url(forResource: "3crBXeO", withExtension: "gif")!
     let imageURL2 = url(forResource: "kYkLkPf", withExtension: "gif")!
@@ -242,14 +271,13 @@ class ZipTests: XCTestCase {
       password: "password",
       progress: nil
     )
-    let fileManager = FileManager.default
     let directoryName = zipFilePath.lastPathComponent.replacingOccurrences(
       of: ".\(zipFilePath.pathExtension)",
       with: ""
     )
     let destinationUrl = try autoRemovingSandbox()
       .appendingPathComponent(directoryName, isDirectory: true)
-    try XCTAssertThrowsError(
+    XCTAssertThrowsError(
       try Zip.unzipFile(
         zipFilePath,
         destination: destinationUrl,


### PR DESCRIPTION
Not entirely sure if this is the correct way to check for this, but it works for my case.